### PR TITLE
Fixing resizing bug of fontawesome icons

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -8,6 +8,10 @@ import PopularTagsAside from "../components/PopularTagsAside";
 import TagLink from "../components/TagLink";
 import SideMenu from "../components/SideMenu";
 
+import '@fortawesome/fontawesome-svg-core/styles.css';
+import { config } from '@fortawesome/fontawesome-svg-core';
+config.autoAddCss = false;
+
 const Index = ({ order }) => {
   const router = useRouter();
   const [orderType, setOrderType] = useState(order || POPULAR);


### PR DESCRIPTION
The icons added in #9 resized when changing the order (e.g. from "Recent" to "Popular").
These changes should fix this issue.